### PR TITLE
Do not require a description when creating a new vis

### DIFF
--- a/src/js/model/VisFile.js
+++ b/src/js/model/VisFile.js
@@ -173,8 +173,8 @@
                 path: "/item",
                 data: {
                     folderId: options.folderId,
-                    name: this.get("title") || "new vis",
-                    description: this.get("description") || "new descriptionless vis!!"
+                    name: this.get("title"),
+                    description: this.get("description") || ""
                 },
                 success: _.bind(function (item) {
                     var finalize,

--- a/src/js/view/NewVis.js
+++ b/src/js/view/NewVis.js
@@ -17,7 +17,6 @@
 
             validateName = _.bind(function () {
                 var name,
-                    desc,
                     me;
 
                 me = d3.select(this.el);
@@ -25,10 +24,7 @@
                 name = me.select(".vis-name")
                     .property("value");
 
-                desc = me.select(".vis-description")
-                    .property("value");
-
-                if (name && desc) {
+                if (name) {
                     this.enableNext();
                 } else {
                     this.disableNext();


### PR DESCRIPTION
If no description is given during new vis creation:
- the title will still validate
- a blank description will be used to create the Girder item for the new vis