### PR TITLE
Adding username-specific routes

### DIFF
--- a/src/jade/templates/galleryNotFound.jade
+++ b/src/jade/templates/galleryNotFound.jade
@@ -1,0 +1,3 @@
+.alert.alert-danger
+    p: strong There doesn't seem to be an account named #[em #{username}].
+    p Use the navigation controls above to continue.

--- a/src/jade/templates/item.jade
+++ b/src/jade/templates/item.jade
@@ -2,29 +2,41 @@ include ../mixins/modal.jade
 
 .container
     .row
-        h1 #[span #{title}] #[a(href="#") #[span.glyphicon.glyphicon-pencil.normal-font-size]]
-        .placard.title-placard.hidden
-            .placard-popup
-            input.form-control.placard-field(type="text")
-            .placard-footer
-                a.placard-cancel(href="#") Cancel
-                button.btn.btn-primary.btn-xs.placard-accept(type="button") Save
+        if allowEdit
+            h1 #[span #{title}] #[a(href="#") #[span.glyphicon.glyphicon-pencil.normal-font-size]]
+        else
+            h1 #[span #{title}] #[a(href="#")]
+
+        if allowEdit
+            .placard.title-placard.hidden
+                .placard-popup
+                input.form-control.placard-field(type="text")
+                .placard-footer
+                    a.placard-cancel(href="#") Cancel
+                    button.btn.btn-primary.btn-xs.placard-accept(type="button") Save
     .row
-        h2 #[span #{description}] #[a(href="#") #[span.glyphicon.glyphicon-pencil.normal-font-size]]
-        .placard.description-placard.hidden
-            .placard-popup
-            textarea.form-control.placard-field
-            .placard-footer
-                a.placard-cancel(href="#") Cancel
-                button.btn.btn-primary.btn-xs.placard-accept(type="button") Save
+        if allowEdit
+            h2 #[span #{description}] #[a(href="#") #[span.glyphicon.glyphicon-pencil.normal-font-size]]
+        else
+            h2 #[span #{description}] #[a(href="#")]
+
+        if allowEdit
+            .placard.description-placard.hidden
+                .placard-popup
+                textarea.form-control.placard-field
+                .placard-footer
+                    a.placard-cancel(href="#") Cancel
+                    button.btn.btn-primary.btn-xs.placard-accept(type="button") Save
     .row
         .vis.border
     .row
-        a(href="/lyra/?editormode=#{tag}" target="_blank").edit: span.glyphicon.glyphicon-pencil
+        if allowEdit
+            a(href="/lyra/?editormode=#{tag}" target="_blank").edit: span.glyphicon.glyphicon-pencil
         .btn-group
             a(data-toggle="dropdown").virtual-link.dropdown-toggle.export: span.glyphicon.glyphicon-download-alt
             ul(role="menu").dropdown-menu
                 li #[a.virtual-link.export-png PNG]
                 li #[a.virtual-link.export-svg SVG]
                 li #[a.virtual-link.export-vega Vega]
-        a.virtual-link.pull-right.delete: span(style="color: red;").glyphicon.glyphicon-trash
+        if allowEdit
+            a.virtual-link.pull-right.delete: span(style="color: red;").glyphicon.glyphicon-trash

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,7 +1,7 @@
-/* jshint browser: true, jquery: true */
+/* jshint browser: true */
 /* global Backbone, girder */
 
-$(function () {
+Backbone.$(function () {
     "use strict";
 
     var app = window.app;
@@ -9,26 +9,22 @@ $(function () {
     // Initialize Girder.
     girder.apiRoot = "/plugin/girder/girder/api/v1";
 
-    // A "sitar root", meaning a girder user coupled with folder ids for data
-    // and visualizations belonging to that user.
-    app.home = new app.model.SitarRoot();
-    girder.events.on("g:login.success", function (userData) {
-        app.home.user.set(userData);
-    });
-    girder.events.on("g:logout.success", app.home.user.clear, app.home.user);
+    // The logged in Girder user.
+    app.user = new girder.models.UserModel();
 
+    // A router to control the URL and page content.
     app.router = new app.router.Router();
 
     // Check for a logged in user, and proceed from here.
     girder.fetchCurrentUser()
         .then(function (userData) {
             if (userData) {
-                app.home.user.set(userData);
+                app.user.set(userData);
             }
 
             // A view for the navbar.
             app.navbar = new app.view.Navbar({
-                model: app.home.user,
+                model: app.user,
                 el: "#navbar"
             });
             app.navbar.render();

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -30,5 +30,9 @@ Backbone.$(function () {
             app.navbar.render();
 
             Backbone.history.start();
+
+            app.router.navigate("", {
+                trigger: true
+            });
         });
 });

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -7,7 +7,7 @@
     app.router.Router = Backbone.Router.extend({
         routes: {
             "": "login",
-            gallery: "gallery",
+            "gallery(/:username)": "gallery",
             "vis/new": "create",
             "vis/:itemId": "item"
         },

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -1,5 +1,5 @@
 /* jshint browser: true */
-/* global Backbone, _, d3 */
+/* global Backbone, _, d3, girder */
 
 (function (app) {
     "use strict";
@@ -86,15 +86,24 @@
             if (app.user.isNew()) {
                 this.setjmp("vis/" + itemId);
             } else {
-                view = new app.view.Item({
-                    el: d3.select("#content").append("div").node(),
-                    model: new app.model.VisFile({
-                        id: itemId
-                    })
-                });
+                // Learn who the owner of the vis is.
+                girder.restRequest({
+                    method: "GET",
+                    path: "/item/" + itemId + "/rootpath"
+                }).then(_.bind(function (path) {
+                    var owner = path[0].object.login;
 
-                app.navbar.show();
-                this.replaceView(view);
+                    view = new app.view.Item({
+                        el: d3.select("#content").append("div").node(),
+                        model: new app.model.VisFile({
+                            id: itemId
+                        }),
+                        allowEdit: app.user.get("login") === owner
+                    });
+
+                    app.navbar.show();
+                    this.replaceView(view);
+                }, this));
             }
         },
 

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -57,7 +57,8 @@
         },
 
         gallery: function (username) {
-            var view,
+            var contentNode,
+                show,
                 home;
 
             username = username || app.user.get("login");
@@ -66,17 +67,33 @@
                 login: username
             });
 
+            show = _.bind(function (view) {
+                app.navbar.show();
+                this.replaceView(view);
+            }, this);
+
+            contentNode = d3.select("#content")
+                .append("div")
+                .node();
+
             home.fetch().then(_.bind(function () {
-                view = new app.view.Gallery({
+                var view = new app.view.Gallery({
                     collection: new app.collection.Visualizations({
                         home: home
                     }),
-                    el: d3.select("#content").append("div").node(),
+                    el: contentNode,
                     newvis: app.user.get("login") === home.login
                 });
 
-                app.navbar.show();
-                this.replaceView(view);
+                show(view);
+            }, this), _.bind(function () {
+                var view = new app.view.GalleryNotFound({
+                    el: contentNode,
+                    username: username
+                });
+
+                view.render();
+                show(view);
             }, this));
         },
 

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -38,7 +38,7 @@
         login: function () {
             var view;
 
-            if (app.home.user.isNew()) {
+            if (app.user.isNew()) {
                 view = new app.view.Login({
                     el: d3.select("#content").append("div").classed("down", true).node()
                 });
@@ -49,34 +49,32 @@
 
                 app.navbar.hide();
                 this.replaceView(view);
-            } else {
+
                 this.longjmp("gallery");
             }
         },
 
-        gallery: function () {
-            var view;
+        gallery: function (username) {
+            var view,
+                home;
 
-            if (app.home.user.isNew()) {
-                this.setjmp("gallery");
-            } else if (!app.home.isValid()) {
-                app.home.fetch({
-                    success: _.bind(function () {
-                        this.gallery();
-                        return;
-                    }, this)
-                });
-            } else {
+            username = username || app.user.get("login");
+
+            home = new app.model.SitarRoot({
+                login: username
+            });
+
+            home.fetch().then(_.bind(function () {
                 view = new app.view.Gallery({
                     collection: new app.collection.Visualizations({
-                        home: app.home
+                        home: home
                     }),
                     el: d3.select("#content").append("div").node()
                 });
 
                 app.navbar.show();
                 this.replaceView(view);
-            }
+            }, this));
         },
 
         item: function (itemId) {

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -80,15 +80,8 @@
         item: function (itemId) {
             var view;
 
-            if (app.home.user.isNew()) {
+            if (app.user.isNew()) {
                 this.setjmp("vis/" + itemId);
-            } else if (!app.home.isValid()) {
-                app.home.fetch({
-                    success: _.bind(function () {
-                        this.item(itemId);
-                        return;
-                    }, this)
-                });
             } else {
                 view = new app.view.Item({
                     el: d3.select("#content").append("div").node(),
@@ -105,7 +98,7 @@
         create: function () {
             var view;
 
-            if (app.home.user.isNew()) {
+            if (app.user.isNew()) {
                 this.setjmp("vis/new");
             } else {
                 view = new app.view.NewVis({

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -49,8 +49,10 @@
 
                 app.navbar.hide();
                 this.replaceView(view);
-
-                this.longjmp("gallery");
+            } else {
+                this.navigate("gallery", {
+                    trigger: true
+                });
             }
         },
 

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -71,7 +71,8 @@
                     collection: new app.collection.Visualizations({
                         home: home
                     }),
-                    el: d3.select("#content").append("div").node()
+                    el: d3.select("#content").append("div").node(),
+                    newvis: app.user.get("login") === home.login
                 });
 
                 app.navbar.show();

--- a/src/js/view/Gallery.js
+++ b/src/js/view/Gallery.js
@@ -7,7 +7,9 @@
     // A preview gallery of the vis files in a VisFiles collection.  Made up of
     // GalleryItems, arranged in rows on the screen.
     app.view.Gallery = Backbone.View.extend({
-        initialize: function () {
+        initialize: function (options) {
+            options = options || {};
+
             if (!this.collection) {
                 throw new Error("fatal: must specify 'collection'");
             }
@@ -20,6 +22,8 @@
                 .classed("container", true);
 
             this.items = [];
+
+            this.newvis = options.newvis;
 
             this.listenTo(this.collection, "sync", _.debounce(this.render, 500));
 
@@ -34,19 +38,21 @@
                 .append("div")
                 .classed("row", true);
 
-            html = app.templates.galleryItem({
-                posterUrl: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNTUiIGhlaWdodD0iMTE4Ij48cmVjdCB3aWR0aD0iMTU1IiBoZWlnaHQ9IjExOCIgZmlsbD0iI2VlZSIvPjx0ZXh0IHRleHQtYW5jaG9yPSJtaWRkbGUiIHg9Ijc3LjUiIHk9IjU5IiBzdHlsZT0iZmlsbDojYWFhO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1zaXplOjQ4cHg7Zm9udC1mYW1pbHk6QXJpYWwsSGVsdmV0aWNhLHNhbnMtc2VyaWY7ZG9taW5hbnQtYmFzZWxpbmU6Y2VudHJhbCI+KzwvdGV4dD48L3N2Zz4K",
-                title: "Create New Visualization",
-                description: ""
-            });
-
-            row.append("div")
-                .classed("col-md-2", true)
-                .html(html)
-                .select("a.thumbnail")
-                .on("click", function () {
-                    app.router.navigate("vis/new", {trigger: true});
+            if (this.newvis) {
+                html = app.templates.galleryItem({
+                    posterUrl: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNTUiIGhlaWdodD0iMTE4Ij48cmVjdCB3aWR0aD0iMTU1IiBoZWlnaHQ9IjExOCIgZmlsbD0iI2VlZSIvPjx0ZXh0IHRleHQtYW5jaG9yPSJtaWRkbGUiIHg9Ijc3LjUiIHk9IjU5IiBzdHlsZT0iZmlsbDojYWFhO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1zaXplOjQ4cHg7Zm9udC1mYW1pbHk6QXJpYWwsSGVsdmV0aWNhLHNhbnMtc2VyaWY7ZG9taW5hbnQtYmFzZWxpbmU6Y2VudHJhbCI+KzwvdGV4dD48L3N2Zz4K",
+                    title: "Create New Visualization",
+                    description: ""
                 });
+
+                row.append("div")
+                    .classed("col-md-2", true)
+                    .html(html)
+                    .select("a.thumbnail")
+                    .on("click", function () {
+                        app.router.navigate("vis/new", {trigger: true});
+                    });
+            }
 
             this.collection.each(function (visfile, i) {
                 var view,

--- a/src/js/view/GalleryNotFound.js
+++ b/src/js/view/GalleryNotFound.js
@@ -1,0 +1,20 @@
+/* jshint browser: true */
+/* global Backbone */
+
+(function (app) {
+    "use strict";
+
+    app.view.GalleryNotFound = Backbone.View.extend({
+        initialize: function (options) {
+            options = options || {};
+
+            this.username = options.username;
+        },
+
+        render: function () {
+            this.$el.html(app.templates.galleryNotFound({
+                username: this.username
+            }));
+        }
+    });
+}(window.app));

--- a/src/js/view/Login.js
+++ b/src/js/view/Login.js
@@ -134,8 +134,8 @@
                     this.$("#register-dialog").modal("hide");
 
                     this.$("#register-dialog").on("hidden.bs.modal", function () {
-                        app.home.user.current();
-                        app.home.user.once("change", function () {
+                        app.user.current();
+                        app.user.once("change", function () {
                             app.router.longjmp("gallery");
                         });
                     });
@@ -168,7 +168,9 @@
 
             // Attempt to log the user in if not already logged in.
             girder.login(username, password)
-                .then(function () {
+                .then(function (user) {
+                    app.user.set(user);
+
                     d3.select("#jumpback")
                         .classed("hidden", true);
 

--- a/src/js/view/Navbar.js
+++ b/src/js/view/Navbar.js
@@ -38,12 +38,10 @@
         },
 
         logout: function () {
-            girder.logout()
-                .then(function () {
-                    app.router.setjmp(null);
-                }, function () {
-                    throw new Error("the impossible has happened");
-                });
+            girder.logout();
+            app.user.clear();
+
+            app.router.setjmp(null);
         }
     });
 }(window.app));


### PR DESCRIPTION
This adds an optional argument to the ``/#gallery`` route, so it becomes (in Backbone terms) ``/#gallery(/:username)`` - that is to say, the route now accepts a username.  By default, the username is that of the logged-in user.

When the route is invoked this way, the gallery will display visualizations from the named user's account.  Additionally, there will be no "add new visualization" option if the requested user is not the same as the logged-in user; similarly, in this scenario, the visualization item display will not have the "edit" icons (i.e., no pencil icons for the title and description, and no pencil or garbage can icons for the vis itself).

Closes #31