### PR TITLE
Support debugging console.log() more easily

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,7 +72,10 @@ module.exports = function (grunt) {
                 eqnull: true,
 
                 // Environment options.
-                browser: true
+                browser: true,
+
+                // Set this to true for debugging, false for release.
+                devel: false
             },
             all: ["Gruntfile.js", "src/js/**/*.js"]
         },


### PR DESCRIPTION
Adds a ``devel`` option to the ``jshint`` of ``Gruntfile.js``.  Now, to use ``console.log()`` in any file, just change the option to ``true``; before merging a PR, be sure to change it back to ``false`` and remove all the ``console.log()``s.