### PR TITLE
Anonymous browsing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,8 @@ module.exports = function (grunt) {
         uglify: {
             index: {
                 options: {
-                    sourceMap: true
+                    sourceMap: true,
+                    sourceMapIncludeSources: true
                 },
                 files: {
                     "build/site/js/index.min.js": ["src/js/index.js"],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,7 +72,10 @@ module.exports = function (grunt) {
                 eqnull: true,
 
                 // Environment options.
-                browser: true
+                browser: true,
+
+                // Set this to true for debugging, false for release.
+                devel: false
             },
             all: ["Gruntfile.js", "src/js/**/*.js"]
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
                 browser: true,
 
                 // Set this to true for debugging, false for release.
-                devel: true
+                devel: false
             },
             all: ["Gruntfile.js", "src/js/**/*.js"]
         },
@@ -90,7 +90,7 @@ module.exports = function (grunt) {
                 options: {
                     sourceMap: true,
                     sourceMapIncludeSources: true,
-                    beautify: true
+                    beautify: false
                 },
                 files: {
                     "build/site/js/index.min.js": ["src/js/index.js"],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
                 browser: true,
 
                 // Set this to true for debugging, false for release.
-                devel: false
+                devel: true
             },
             all: ["Gruntfile.js", "src/js/**/*.js"]
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,8 @@ module.exports = function (grunt) {
             index: {
                 options: {
                     sourceMap: true,
-                    sourceMapIncludeSources: true
+                    sourceMapIncludeSources: true,
+                    beautify: true
                 },
                 files: {
                     "build/site/js/index.min.js": ["src/js/index.js"],

--- a/src/jade/mixins/gallery.jade
+++ b/src/jade/mixins/gallery.jade
@@ -4,8 +4,8 @@ mixin gallery(items, rowLength)
     for i in _.range(numRows)
         .row
             for j in _.range(rowLength)
-                .col-md-2 hello
+                .col-md-2.item
     if stragglers > 0
         .row
             for j in _.range(stragglers)
-                .col-md-2 hello
+                .col-md-2.item

--- a/src/jade/mixins/gallery.jade
+++ b/src/jade/mixins/gallery.jade
@@ -1,0 +1,11 @@
+mixin gallery(items, rowLength)
+    - var numRows = Math.floor(items / rowLength);
+    - var stragglers = items - numRows * rowLength;
+    for i in _.range(numRows)
+        .row
+            for j in _.range(rowLength)
+                .col-md-2 hello
+    if stragglers > 0
+        .row
+            for j in _.range(stragglers)
+                .col-md-2 hello

--- a/src/jade/mixins/galleryItem.jade
+++ b/src/jade/mixins/galleryItem.jade
@@ -1,0 +1,8 @@
+mixin galleryItem(title, description, posterUrl)
+    a(class="thumbnail virtual-link"): img(src="#{posterUrl}")
+    .row
+        div(class="col-md-12")
+            p.title #{title}
+    .row
+        div(class="col-md-12")
+            p #{description}

--- a/src/jade/templates/browse.jade
+++ b/src/jade/templates/browse.jade
@@ -1,0 +1,5 @@
+for user in users
+    .panel.panel-default
+        .panel-heading
+            h1.panel-title #[a(href="/#gallery/#{user}") #{user}]
+        .panel-body

--- a/src/jade/templates/browse.jade
+++ b/src/jade/templates/browse.jade
@@ -3,3 +3,4 @@ for user in users
         .panel-heading
             h1.panel-title #[a(href="/#gallery/#{user}") #{user}]
         .panel-body
+            .gallery

--- a/src/jade/templates/gallery.jade
+++ b/src/jade/templates/gallery.jade
@@ -1,0 +1,4 @@
+include ../mixins/gallery.jade
+
+div
+    +gallery(items, rowLength)

--- a/src/jade/templates/galleryItem.jade
+++ b/src/jade/templates/galleryItem.jade
@@ -1,7 +1,3 @@
-a(class="thumbnail virtual-link"): img(src="#{posterUrl}")
-.row
-    div(class="col-md-12")
-        p.title #{title}
-.row
-    div(class="col-md-12")
-        p #{description}
+include ../mixins/galleryItem.jade
+
++galleryItem(title, description, posterUrl)

--- a/src/jade/templates/login.jade
+++ b/src/jade/templates/login.jade
@@ -29,10 +29,10 @@ include ../mixins/modal.jade
     p.
         If you just want to take a look around you can also #[a(href="/#browse") browse anonymously].
 
-    .alert.alert-info(class=jumpback ? "" : "hidden")#jumpback.
+    .alert.alert-info.text-center(class=jumpback ? "" : "hidden")#jumpback.
         After login, you will be returned to the page you came here from.  Enjoy!
 
-    .alert.alert-danger.hidden#failed.
+    .alert.alert-danger.text-center.hidden#failed.
         Username or password incorrect.
 
     p.footer.

--- a/src/jade/templates/login.jade
+++ b/src/jade/templates/login.jade
@@ -26,6 +26,9 @@ include ../mixins/modal.jade
                 span.col-md-2
                     button(type="button" data-toggle="modal" data-target="#register-dialog").btn.btn-lg.btn-info.btn-block.register Register
 
+    p.
+        If you just want to take a look around you can also #[a(href="/#browse") browse anonymously].
+
     .alert.alert-info(class=jumpback ? "" : "hidden")#jumpback.
         You must be logged in to visit that page.  Please log in and we will return you there.
 

--- a/src/jade/templates/login.jade
+++ b/src/jade/templates/login.jade
@@ -30,7 +30,7 @@ include ../mixins/modal.jade
         If you just want to take a look around you can also #[a(href="/#browse") browse anonymously].
 
     .alert.alert-info(class=jumpback ? "" : "hidden")#jumpback.
-        You must be logged in to visit that page.  Please log in and we will return you there.
+        After login, you will be returned to the page you came here from.  Enjoy!
 
     .alert.alert-danger.hidden#failed.
         Username or password incorrect.

--- a/src/jade/templates/navbar.jade
+++ b/src/jade/templates/navbar.jade
@@ -10,6 +10,6 @@ nav.navbar.navbar-default
                             | #[span #{name}] #[span.caret]
                         ul.dropdown-menu(role="menu")
                             li
-                                a(href="#").logout Logout
+                                a.virtual-link.logout Logout
                 else
-                    li: a#navbar-login.virtual-link Login
+                    li: a.login.virtual-link Login

--- a/src/jade/templates/navbar.jade
+++ b/src/jade/templates/navbar.jade
@@ -12,4 +12,4 @@ nav.navbar.navbar-default
                             li
                                 a(href="#").logout Logout
                 else
-                    li: a(href="#") Login
+                    li: a#navbar-login.virtual-link Login

--- a/src/jade/templates/navbar.jade
+++ b/src/jade/templates/navbar.jade
@@ -1,8 +1,13 @@
 nav.navbar.navbar-default
     .container-fluid
         .navbar-header
-            a.navbar-brand(href="#") Sitar
+            a.navbar-brand(href="https://github.com/XDATA-Year-2/sitar" target="_blank") Sitar
         .collapse.navbar-collapse
+            if name
+                ul.nav.navbar-nav
+                    li: a(href="#gallery") My Visualizations
+            ul.nav.navbar-nav
+                li: a(href="#browse") Browse
             ul.nav.navbar-nav.navbar-right
                 if name
                     li.dropdown

--- a/src/jade/templates/navbar.jade
+++ b/src/jade/templates/navbar.jade
@@ -4,9 +4,12 @@ nav.navbar.navbar-default
             a.navbar-brand(href="#") Sitar
         .collapse.navbar-collapse
             ul.nav.navbar-nav.navbar-right
-                li.dropdown
-                    a.dropdown-toggle(data-toggle="dropdown" role="button" aria-expanded="false")
-                        | #[span #{name}] #[span.caret]
-                    ul.dropdown-menu(role="menu")
-                        li
-                            a(href="#").logout Logout
+                if name
+                    li.dropdown
+                        a.dropdown-toggle(data-toggle="dropdown" role="button" aria-expanded="false")
+                            | #[span #{name}] #[span.caret]
+                        ul.dropdown-menu(role="menu")
+                            li
+                                a(href="#").logout Logout
+                else
+                    li: a(href="#") Login

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -30,9 +30,5 @@ Backbone.$(function () {
             app.navbar.render();
 
             Backbone.history.start();
-
-            app.router.navigate("", {
-                trigger: true
-            });
         });
 });

--- a/src/js/model/VisFile.js
+++ b/src/js/model/VisFile.js
@@ -156,6 +156,8 @@
                     path: url,
                     success: callback(i),
                     error: this.errorHandler(options)
+                }).then(function () {
+                    console.log("fetch", url);
                 });
             }, this));
         },

--- a/src/js/model/VisFile.js
+++ b/src/js/model/VisFile.js
@@ -156,8 +156,6 @@
                     path: url,
                     success: callback(i),
                     error: this.errorHandler(options)
-                }).then(function () {
-                    console.log("fetch", url);
                 });
             }, this));
         },

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -137,28 +137,24 @@
         item: function (itemId) {
             var view;
 
-            if (app.user.isNew()) {
-                this.setjmp("vis/" + itemId);
-            } else {
-                // Learn who the owner of the vis is.
-                girder.restRequest({
-                    method: "GET",
-                    path: "/item/" + itemId + "/rootpath"
-                }).then(_.bind(function (path) {
-                    var owner = path[0].object.login;
+            // Learn who the owner of the vis is.
+            girder.restRequest({
+                method: "GET",
+                path: "/item/" + itemId + "/rootpath"
+            }).then(_.bind(function (path) {
+                var owner = path[0].object.login;
 
-                    view = new app.view.Item({
-                        el: d3.select("#content").append("div").node(),
-                        model: new app.model.VisFile({
-                            id: itemId
-                        }),
-                        allowEdit: app.user.get("login") === owner
-                    });
+                view = new app.view.Item({
+                    el: d3.select("#content").append("div").node(),
+                    model: new app.model.VisFile({
+                        id: itemId
+                    }),
+                    allowEdit: app.user.get("login") === owner
+                });
 
-                    app.navbar.show();
-                    this.replaceView(view);
-                }, this));
-            }
+                app.navbar.show();
+                this.replaceView(view);
+            }, this));
         },
 
         create: function () {

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -129,6 +129,7 @@
                 });
 
                 view.render();
+                app.navbar.show();
                 this.replaceView(view);
             }, this));
         },

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -1,4 +1,4 @@
-/* jshint browser: true, devel: true */
+/* jshint browser: true */
 /* global Backbone, _, d3, girder */
 
 (function (app) {
@@ -161,20 +161,28 @@
         },
 
         create: function () {
-            var view;
+            var view,
+                home;
 
             if (app.user.isNew()) {
                 this.setjmp("vis/new");
             } else {
-                view = new app.view.NewVis({
-                    el: d3.select("#content").append("div").node(),
-                    model: new app.model.VisFile()
+                home = new app.model.SitarRoot({
+                    login: app.user.get("login")
                 });
 
-                view.render();
+                home.fetch().then(_.bind(function () {
+                    view = new app.view.NewVis({
+                        el: d3.select("#content").append("div").node(),
+                        model: new app.model.VisFile(),
+                        home: home
+                    });
 
-                app.navbar.show();
-                this.replaceView(view);
+                    view.render();
+
+                    app.navbar.show();
+                    this.replaceView(view);
+                }, this));
             }
         },
 

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -1,4 +1,4 @@
-/* jshint browser: true */
+/* jshint browser: true, devel: true */
 /* global Backbone, _, d3, girder */
 
 (function (app) {
@@ -8,6 +8,7 @@
         routes: {
             "": "login",
             "gallery(/:username)": "gallery",
+            "browse": "browse",
             "vis/new": "create",
             "vis/:itemId": "item"
         },
@@ -94,6 +95,41 @@
 
                 view.render();
                 show(view);
+            }, this));
+        },
+
+        browse: function () {
+            // Get a list of users on the system.
+            girder.restRequest({
+                method: "GET",
+                path: "/user"
+            }).then(_.bind(function (users) {
+                var logins = _.pluck(users, "login"),
+                    homes = [],
+                    loggedIn = app.user.get("login"),
+                    me,
+                    view;
+                
+                _.each(logins, function (login) {
+                    var home = new app.model.SitarRoot({
+                        login: login
+                    });
+
+                    if (login === loggedIn) {
+                        me = home;
+                    } else {
+                        homes.push(home);
+                    }
+                });
+
+                view = new app.view.Browse({
+                    el: d3.select("#content").append("div").node(),
+                    focus: me,
+                    homes: homes
+                });
+
+                view.render();
+                this.replaceView(view);
             }, this));
         },
 

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -59,10 +59,22 @@
 
         gallery: function (username) {
             var contentNode,
+                login,
                 show,
                 home;
 
-            username = username || app.user.get("login");
+            if (!username) {
+                login = app.user.get("login");
+                if (login) {
+                    this.navigate("gallery/" + login, {
+                        trigger: true
+                    });
+                } else {
+                    this.navigate("browse", {
+                        trigger: true
+                    });
+                }
+            }
 
             home = new app.model.SitarRoot({
                 login: username

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -104,6 +104,8 @@
                 method: "GET",
                 path: "/user"
             }).then(_.bind(function (users) {
+                console.log(users);
+
                 var logins = _.pluck(users, "login"),
                     homes = [],
                     loggedIn = app.user.get("login"),

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -74,6 +74,8 @@
                         trigger: true
                     });
                 }
+
+                return;
             }
 
             home = new app.model.SitarRoot({

--- a/src/js/router/Router.js
+++ b/src/js/router/Router.js
@@ -104,14 +104,12 @@
                 method: "GET",
                 path: "/user"
             }).then(_.bind(function (users) {
-                console.log(users);
-
                 var logins = _.pluck(users, "login"),
                     homes = [],
                     loggedIn = app.user.get("login"),
                     me,
                     view;
-                
+
                 _.each(logins, function (login) {
                     var home = new app.model.SitarRoot({
                         login: login

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -6,6 +6,10 @@
 
     app.util = app.util || {};
 
+    app.util.currentUrl = function () {
+        return window.location.hash.slice(1) + window.location.search;
+    };
+
     app.util.getGirderTokenCookie = function () {
         var cookies = document.cookie.split("; ")
             .map(function (s) {

--- a/src/js/view/Browse.js
+++ b/src/js/view/Browse.js
@@ -31,7 +31,7 @@
             // the DOM the panels that don't contain any.
             cullEmpty = _.after(allHomes.length, function () {
                 var panels = d3.selectAll(".panel-body"),
-                    itemGroups = panels.selectAll(".col-md-2");
+                    itemGroups = panels.selectAll(".item");
 
                 _.each(_.range(itemGroups.length), function (i) {
                     if (itemGroups[i].length === 0) {
@@ -42,7 +42,7 @@
             });
 
             d3.select(this.el)
-                .selectAll(".panel-body")
+                .selectAll(".gallery")
                 .data(allHomes)
                 .each(function (home, i) {
                     home.fetch().then(_.bind(function () {

--- a/src/js/view/Browse.js
+++ b/src/js/view/Browse.js
@@ -1,15 +1,52 @@
 /* jshint browser: true */
-/* global Backbone, d3 */
+/* global Backbone, _, d3 */
 
 (function (app) {
     "use strict";
 
     // A preview gallery of the vis files in a VisFiles collection.  Made up of
-    // GalleryItems, arranged in rows on the screen.
+    // Galleries, one per user.
     app.view.Browse = Backbone.View.extend({
+        initialize: function (options) {
+            options = options || {};
+
+            this.focus = options.focus;
+            this.homes = options.homes;
+
+            if (!this.homes) {
+                throw new Error("option 'homes' is required");
+            }
+        },
+
         render: function () {
+            var allHomes = (this.focus ? [this.focus] : []).concat(this.homes),
+                that = this;
+
+            this.$el.html(app.templates.browse({
+                users: _.pluck(allHomes, "login")
+            }));
+
+            console.log(this.focus);
+
             d3.select(this.el)
-                .html("<h1>Hello</h1>");
+                .selectAll(".panel-body")
+                .data(allHomes)
+                .each(function (home, i) {
+                    home.fetch().then(_.bind(function () {
+                        console.log("i", i);
+                        console.log("focus", that.focus);
+                        console.log("cond", that.focus && (i === 0));
+                        var view = new app.view.Gallery({
+                            el: this,
+                            collection: new app.collection.Visualizations({
+                                home: home
+                            }),
+                            newvis: that.focus && (i === 0)
+                        });
+
+                        view.render();
+                    }, this));
+                });
         }
     });
 }(window.app));

--- a/src/js/view/Browse.js
+++ b/src/js/view/Browse.js
@@ -1,0 +1,15 @@
+/* jshint browser: true */
+/* global Backbone, d3 */
+
+(function (app) {
+    "use strict";
+
+    // A preview gallery of the vis files in a VisFiles collection.  Made up of
+    // GalleryItems, arranged in rows on the screen.
+    app.view.Browse = Backbone.View.extend({
+        render: function () {
+            d3.select(this.el)
+                .html("<h1>Hello</h1>");
+        }
+    });
+}(window.app));

--- a/src/js/view/Gallery.js
+++ b/src/js/view/Gallery.js
@@ -65,6 +65,8 @@
                         }));
                     }
                 });
+
+            this.trigger("render");
         }
     });
 }(window.app));

--- a/src/js/view/Gallery.js
+++ b/src/js/view/Gallery.js
@@ -18,9 +18,6 @@
                 throw new Error("fatal: must specify 'el'");
             }
 
-            d3.select(this.el)
-                .classed("container", true);
-
             this.items = [];
 
             this.newvis = options.newvis || false;
@@ -35,11 +32,11 @@
 
             this.$el.html(app.templates.gallery({
                 items: this.collection.length + this.newvis,
-                rowLength: 5
+                rowLength: 6
             }));
 
             d3.select(this.el)
-                .selectAll(".col-md-2")
+                .selectAll(".item")
                 .data((this.newvis ? ["newvis"] : []).concat(this.collection.models))
                 .each(function (visfile) {
                     if (_.isString(visfile)) {

--- a/src/js/view/Gallery.js
+++ b/src/js/view/Gallery.js
@@ -23,7 +23,7 @@
 
             this.items = [];
 
-            this.newvis = options.newvis;
+            this.newvis = options.newvis || false;
 
             this.listenTo(this.collection, "sync", _.debounce(this.render, 500));
 

--- a/src/js/view/Gallery.js
+++ b/src/js/view/Gallery.js
@@ -31,52 +31,40 @@
         },
 
         render: function () {
-            var row,
-                html;
+            var that = this;
 
-            row = d3.select(this.el)
-                .append("div")
-                .classed("row", true);
+            this.$el.html(app.templates.gallery({
+                items: this.collection.length + this.newvis,
+                rowLength: 5
+            }));
 
-            if (this.newvis) {
-                html = app.templates.galleryItem({
-                    posterUrl: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNTUiIGhlaWdodD0iMTE4Ij48cmVjdCB3aWR0aD0iMTU1IiBoZWlnaHQ9IjExOCIgZmlsbD0iI2VlZSIvPjx0ZXh0IHRleHQtYW5jaG9yPSJtaWRkbGUiIHg9Ijc3LjUiIHk9IjU5IiBzdHlsZT0iZmlsbDojYWFhO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1zaXplOjQ4cHg7Zm9udC1mYW1pbHk6QXJpYWwsSGVsdmV0aWNhLHNhbnMtc2VyaWY7ZG9taW5hbnQtYmFzZWxpbmU6Y2VudHJhbCI+KzwvdGV4dD48L3N2Zz4K",
-                    title: "Create New Visualization",
-                    description: ""
+            d3.select(this.el)
+                .selectAll(".col-md-2")
+                .data((this.newvis ? ["newvis"] : []).concat(this.collection.models))
+                .each(function (visfile) {
+                    if (_.isString(visfile)) {
+                        if (visfile === "newvis") {
+                            var html = app.templates.galleryItem({
+                                posterUrl: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNTUiIGhlaWdodD0iMTE4Ij48cmVjdCB3aWR0aD0iMTU1IiBoZWlnaHQ9IjExOCIgZmlsbD0iI2VlZSIvPjx0ZXh0IHRleHQtYW5jaG9yPSJtaWRkbGUiIHg9Ijc3LjUiIHk9IjU5IiBzdHlsZT0iZmlsbDojYWFhO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1zaXplOjQ4cHg7Zm9udC1mYW1pbHk6QXJpYWwsSGVsdmV0aWNhLHNhbnMtc2VyaWY7ZG9taW5hbnQtYmFzZWxpbmU6Y2VudHJhbCI+KzwvdGV4dD48L3N2Zz4K",
+                                title: "Create New Visualization",
+                                description: ""
+                            });
+
+                            d3.select(this)
+                                .html(html)
+                                .on("click", function () {
+                                    app.router.navigate("vis/new", {
+                                        trigger: true
+                                    });
+                                });
+                        }
+                    } else {
+                        that.items.push(new app.view.GalleryItem({
+                            model: visfile,
+                            el: this
+                        }));
+                    }
                 });
-
-                row.append("div")
-                    .classed("col-md-2", true)
-                    .html(html)
-                    .select("a.thumbnail")
-                    .on("click", function () {
-                        app.router.navigate("vis/new", {trigger: true});
-                    });
-            }
-
-            this.collection.each(function (visfile, i) {
-                var view,
-                    div;
-
-                // Every five items, create a new row element.
-                if (i + 1 % 5 === 0) {
-                    row = d3.select(this.el)
-                        .append("div")
-                        .classed("row", true);
-                }
-
-                // Create a GalleryItem and attach it to a new div.
-                div = row.append("div")
-                    .classed("col-md-2", true)
-                    .node();
-
-                view = new app.view.GalleryItem({
-                    model: visfile,
-                    el: div
-                });
-
-                this.items.push(view);
-            }, this);
         }
     });
 }(window.app));

--- a/src/js/view/Navbar.js
+++ b/src/js/view/Navbar.js
@@ -27,6 +27,10 @@
                 .html(app.templates.navbar({
                     name: name
                 }));
+
+            this.$("#navbar-login").on("click", function () {
+                app.router.setjmp(app.util.currentUrl());
+            });
         },
 
         hide: function () {

--- a/src/js/view/Navbar.js
+++ b/src/js/view/Navbar.js
@@ -18,7 +18,7 @@
         },
 
         render: function () {
-            var name = "";
+            var name;
             if (this.model.get("firstName")) {
                 name = this.model.get("firstName") + " " + this.model.get("lastName")[0] + ".";
             }

--- a/src/js/view/Navbar.js
+++ b/src/js/view/Navbar.js
@@ -28,7 +28,7 @@
                     name: name
                 }));
 
-            this.$("#navbar-login").on("click", function () {
+            this.$(".login").on("click", function () {
                 app.router.setjmp(app.util.currentUrl());
             });
         },
@@ -45,7 +45,7 @@
             girder.logout();
             app.user.clear();
 
-            app.router.setjmp(null);
+            window.location.reload();
         }
     });
 }(window.app));

--- a/src/js/view/NewVis.js
+++ b/src/js/view/NewVis.js
@@ -5,8 +5,15 @@
     "use strict";
 
     app.view.NewVis = Backbone.View.extend({
-        initialize: function () {
+        initialize: function (option) {
+            option = option || {};
+
             this.file = null;
+            this.home = option.home;
+
+            if (!this.home) {
+                throw new Error("option 'home' is required");
+            }
         },
 
         render: function () {
@@ -136,7 +143,7 @@
                 .on("keyup", validateNameDebounced);
 
             dataFiles = new app.collection.DataFiles({
-                home: app.home
+                home: this.home
             });
 
             dataFiles.fetch({


### PR DESCRIPTION
You can now use a Sitar instance without logging in.  The following features implement this new mode:
- The login page now has a link that takes the user to the new "browse" route - this view collects thumbnails of all visualizations in the Girder instance and displays them by user.
- Visiting any visualization detail view changes the UI elements as necessary to prevent/allow editing based on whether the user in logged in and looking at one of their visualizations, logged in and looking at someone else's visualization, or not logged in at all.
- The "vis" route now takes an optional extra path component, which must be the name of a user in the system.  In that case, the view displays that user's visualizations.  Visiting the route without supplying a username will redirect to the logged in user if there is one, or to the browse view otherwise.
- The navbar now shows a "login" link in the upper right if no user is logged in.  This link takes the user to the login page, saving the location as it does so.  Upon login, the user will be returned to that route.
- The navbar has a "browse" link leading to the browse view as described above.
- The navbar also shows a "my visualizations" link for a logged in user, which takes the user to his or her gallery page.
- The "Sitar" brand link now opens the GitHub page for sitar in a new window.
